### PR TITLE
Fix pgdog Helm chart ConfigMap: remove extra double quotes and add missing role field

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -78,10 +78,10 @@ data:
     database_name = {{ .databaseName | quote }}
     {{- end }}
     {{- if .user }}
-    user = "{{ .user | quote }}"
+    user = {{ .user | quote }}
     {{- end }}
     {{- if .password }}
-    password = "{{ .password | quote }}"
+    password = {{ .password | quote }}
     {{- end }}
     {{- if .poolSize }}
     pool_size = {{ .poolSize }}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -104,4 +104,7 @@ data:
     {{- if .readOnly }}
     read_only = {{ .readOnly }}
     {{- end }}
+    {{- if .role }}
+    role = {{ .role | quote }}
+    {{- end }}
     {{- end }}


### PR DESCRIPTION
This PR fixes issues in the pgdog Helm chart ConfigMap:

- Removed unintended double quotes around user and password fields that caused authentication failures.
- Added support for the role field under [[databases]], aligning the template with pgdog’s configuration spec.

These changes improve compatibility with pgdog.toml and ensure that database connections work as expected when roles are required.