### PR TITLE
feat: updates to helm chart

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -116,3 +116,8 @@ data:
         exposure = {{ .exposure }}
         {{- end }}
         {{- end }}
+
+        {{- if .Values.adminPassword }}
+        [admin]
+        password = {{ .Values.adminPassword | quote }}
+        {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,3 +55,8 @@ spec:
         - name: prom
           configMap:
             name: {{ include "pgdog.fullname" . }}-prom
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+            

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,7 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pgdog.fullname" . }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: pgdog
 spec:
+  type: {{ .Values.service.type }}
   selector:
     app: pgdog
   ports:
@@ -10,3 +17,7 @@ spec:
       protocol: TCP
       port: {{ .Values.port }}
       targetPort: {{ .Values.port }}
+    - name: openmetrics
+      protocol: TCP
+      port: {{ .Values.openMetricsPort }}
+      targetPort: {{ .Values.openMetricsPort }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "pgdog.fullname" . }}
+spec:
+  endpoints:
+    - path: /
+      port: openmetrics
+  selector:
+    app: pgdog
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,9 @@ openMetricsPort: 9090
 # openMetricsNamespace configures the metrics namespace
 openMetricsNamespace: pgdog_
 
+# Admin password
+# adminPassword: change-me
+
 # databases contains the list of database entries in pgdog.toml
 # Supports all arguments from pgdog.toml. Arguments are named in camelCase format.
 databases: []
@@ -30,3 +33,17 @@ users: []
 
 # mirrors contains a list of databases to replicate traffic from/to.
 mirrors: []
+
+# service contains the Kubernetes service configuration
+service:
+  # type specifies the type of Kubernetes service (ClusterIP, NodePort, LoadBalancer, etc)
+  type: ClusterIP
+  # annotations allows adding custom annotations to the service
+  annotations: {}
+
+# tolerations allows pods to be scheduled on nodes with matching taints
+tolerations: []
+
+# ServiceMonitor for Prometheus metrics
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
- Configurable `Service` type and annotations ( to create service of type LoadBalancer )
   - in `Service` also allow port to openmetrics to make it accessible from load balancer
- Configurable admin password ( to be able to connect as admin for maintenance)
- Configurable tolerations (to schedule pod in desired nodes)