### PR TITLE
Add optional healthcheck_port configuration

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -12,6 +12,9 @@ data:
         default_pool_size         =   {{ .Values.defaultPoolSize | default "10" }}
         min_pool_size             =   {{ .Values.minPoolSize | default "1" }}
         pooler_mode               =   {{ .Values.poolerMode | default "transaction" | quote }}
+        {{- if .Values.healthcheckPort }}
+        healthcheck_port          =   {{ .Values.healthcheckPort }}
+        {{- end }}
         healthcheck_interval      =   {{ .Values.healthcheckInterval | default "30_000" }}
         idle_healthcheck_interval =   {{ .Values.idleHealthcheckInterval | default "30_000" }}
         idle_healthcheck_delay    =   {{ .Values.idleHealthcheckDelay | default "5_000" }}

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,9 @@ image:
   # name: ghcr.io/pgdogdev/pgdog:main
 # port on which PgDog will run.
 port: 6432
+# healthcheckPort on which PgDog will expose healthcheck endpoint
+# (if not specified, no separate healthcheck port is configured)
+# healthcheckPort: 8080
 # replicas indicates how many instances of PgDog will run (HA).
 replicas: 2
 


### PR DESCRIPTION
Adds a healthcheckPort as a configurable value.

Docs: https://docs.pgdog.dev/features/load-balancer/healthchecks/#http-endpoint

(I totally missed this! I was looking in the pgdog.toml general section)

Fixes https://github.com/pgdogdev/helm/issues/12