### PR TITLE
feature: service.spec.trafficDistribution configuration

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -12,6 +12,9 @@ spec:
   type: {{ .Values.service.type }}
   selector:
     {{- include "pgdog.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution | quote }}
+  {{- end }}
   ports:
     - name: pgdog
       protocol: TCP

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,11 @@ service:
   type: ClusterIP
   # annotations allows adding custom annotations to the service
   annotations: {}
+  # traffic distribution mode for Kubernetes service
+  # (PreferClose, PreferSameZone, PreferSameNode)
+  # see https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution for more details.
+  trafficDistribution: ""
+
 
 # tolerations allows pods to be scheduled on nodes with matching taints
 tolerations: []


### PR DESCRIPTION
This adds ability to configure same zone / same node  traffic routing preference for [newer K8S versions](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution).