### PR TITLE
feature: adds support for custom pod annotations

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         {{- include "pgdog.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "pgdog.serviceAccountName" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,9 @@ fullnameOverride: ""
 labels: {}
 selectorLabels: {}
 
+# allows adding custom annotations to the pods
+podAnnotations: {}
+
 # clusterName identifies the Kubernetes cluster (optional)
 # When set, this will be added as a label to all Prometheus metrics
 # clusterName: ""


### PR DESCRIPTION
Adds support for custom pod annotations. I use these for [scraping Prometheus metrics with Datadog](https://docs.datadoghq.com/containers/kubernetes/prometheus/?tab=kubernetesadv2#configuration).