### PR TITLE
Don't quote queryCacheLimit

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -44,7 +44,7 @@ data:
         prepared_statements_limit =   {{ .Values.preparedStatementsLimit }}
         {{- end}}
         {{- if .Values.queryCacheLimit }}
-        query_cache_limit         =   {{ .Values.queryCacheLimit | quote }}
+        query_cache_limit         =   {{ .Values.queryCacheLimit }}
         {{- end }}
         passthrough_auth          =   {{ .Values.passthroughAuth | default "disabled" | quote }}
         connect_timeout           =   {{ .Values.connectTimeout | default "5_000" }}


### PR DESCRIPTION
I believe this is an undocumented configuration, however when I tried to set it I kept getting the following errors on deploy

```
Error: MissingField("invalid type: string \"1000\", expected usize", 18)
```

I can confirm the value was a number and not a string in my config.

which led me to find:
https://github.com/pgdogdev/pgdog/blob/9358fe3e859bd1abfb2e80f6c9cd44aaecf508f4/pgdog/src/config/general.rs#L135-L136 where the value is defined as a `usize`

Forking the repo, removing the `| quote` and using the forked version worked correctly. I verified this by monitoring the `pgdog_query_cache_size` metric and the metric increased as I increased the `queryCacheLimit` value.