### PR TITLE
Add configurable values for log_connections and log_disconnections

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -74,6 +74,8 @@ data:
         openmetrics_port = {{ .Values.openMetricsPort | default "9090" }}
         openmetrics_namespace = {{ .Values.openMetricsNamespace | default "pgdog_" | quote }}
         server_lifetime = {{ .Values.serverLifetime | default "86400000" }}
+        log_connections = {{ .Values.logConnections | default "true" }}
+        log_disconnections = {{ .Values.logDisconnections | default "true" }}
 
         {{- range .Values.databases }}
         [[databases]]


### PR DESCRIPTION
Adds support for the `log_connections` and `log_disconnections` settings in `pgdog.toml. Defaults to `true` to match what is in the docs.