### PR TITLE
configuration option for query_parser_enabled

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -40,6 +40,9 @@ data:
         {{- end}}
         shutdown_timeout          =   {{ .Values.shutdownTimeout | default "60_000" }}
         prepared_statements       =   {{ .Values.preparedStatements | default "extended" | quote }}
+        {{- with .Values.queryParserEnabled }}
+        query_parser_enabled      =   {{ . }}
+        {{- end }}
         {{- if .Values.preparedStatementsLimit }}
         prepared_statements_limit =   {{ .Values.preparedStatementsLimit }}
         {{- end}}


### PR DESCRIPTION
adds configuration option for `query_parser_enabled` added in https://github.com/pgdogdev/pgdog/pull/605 and released with 0.1.15