### PR TITLE
Fix documentation on existing externalSecrets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ externalSecrets:
 externalSecrets:
   enabled: true
   create: false
-  name: "platform-managed-secret"
-  secretName: "my-secret" # Name of Secret it creates
+  secretName: "my-secret" # Name of Secret you created
 ```
 
 ### ServiceAccount & RBAC


### PR DESCRIPTION
The only place in the helm chart where externalSecrets.name is used is within the `templates/externalsecret.yaml` file, within an if for `create: true`.

This means if we have `create: false` there is no need for the name field, and it's confusing.