### PR TITLE
Add LSN check parameters for replication failover auto mode

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -86,6 +86,9 @@ data:
         {{- if hasKey .Values "lsnCheckDelay" }}
         lsn_check_delay           =   {{ .Values.lsnCheckDelay }}
         {{- end }}
+        {{- if hasKey .Values "lsnCheckInterval" }}
+        lsn_check_interval        =   {{ .Values.lsnCheckInterval }}
+        {{- end }}
 
         {{- range .Values.databases }}
         [[databases]]

--- a/values.yaml
+++ b/values.yaml
@@ -323,10 +323,10 @@ queryStats:
   maxErrors: 100
   maxErrorAge: 300000
 
-# LSN check delay for replication failover auto mode (in milliseconds)
-# Set to 0 to start LSN monitoring immediately for automatic replica promotion
+# LSN check configuration for replication failover auto mode (in milliseconds)
 # See: https://docs.pgdog.dev/features/load-balancer/replication-failover/
-# lsnCheckDelay: 0
+# lsnCheckDelay: 0        # Set to 0 to start LSN monitoring immediately
+# lsnCheckInterval: 1000  # How frequently to re-fetch replication status
 
 # TCP keep-alive configuration (optional)
 # These settings control socket-level keep-alive behavior


### PR DESCRIPTION
Adds `lsnCheckDelay` and `lsnCheckInterval` parameters to enable automatic replica promotion
monitoring.

- `lsnCheckDelay`: Delay before starting LSN monitoring (set to 0 for immediate start)
- `lsnCheckInterval`: How frequently to re-fetch replication status

See: https://docs.pgdog.dev/features/load-balancer/replication-failover/