### PR TITLE
Only set read_write_split if present in Values

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -27,7 +27,9 @@ data:
         rollback_timeout          =   {{ .Values.rollbackTimeout | default "5_000" }}
         load_balancing_strategy   =   {{ .Values.loadBalancingStrategy | default "round_robin" | quote }}
         read_write_strategy       =   {{ .Values.readWriteStrategy | default "conservative" | quote }}
-        read_write_split          =   {{ .Values.readWriteSplit | default "exclude_primary" | quote }}
+        {{- if .Values.readWriteSplit }}
+        read_write_split          =   {{ .Values.readWriteSplit | quote }}
+        {{- end }}
         {{- if .Values.tlsCertificate }}
         tls_certificate           =   {{ .Values.tlsCertificate | quote }}
         {{- end }}


### PR DESCRIPTION
As discussed: https://discord.com/channels/1347023905994440806/1347023905994440809/1447041713108549642

The docs list the default value for `read_write_split` as `include_primary`, but the chart defaults to `exclude_primary`. So, we can leave out the setting unless explicitly set so the default will be used.