### PR TITLE
feat: add appVersion to Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,4 @@
 apiVersion: v1
 name: pgdog
 version: v0.28
+appVersion: "0.1.21"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           {{- if .Values.image.name }}
           image: {{ .Values.image.name }}
           {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/pgdog"]

--- a/values.yaml
+++ b/values.yaml
@@ -24,8 +24,8 @@ podAnnotations: {}
 image:
   # repository is the Docker image repository
   repository: ghcr.io/pgdogdev/pgdog
-  # tag is the Docker image tag (defaults to "latest" if not specified)
-  tag: "latest"
+  # tag is the Docker image tag (defaults to Chart appVersion if not specified)
+  tag: ""
   # pullPolicy specifies when to use cached version of the image.
   pullPolicy: IfNotPresent
   # name is the full image name (DEPRECATED: use repository and tag)
@@ -163,7 +163,6 @@ service:
     # scheme controls whether the load balancer is internet-facing or internal
     # Valid values: "internet-facing" or "internal"
     scheme: "internal"
-
 
 # nodeSelector allows scheduling pods on nodes with specific labels
 nodeSelector: {}
@@ -375,7 +374,6 @@ queryStats:
   queryPlansCache: 100
   maxErrors: 100
   maxErrorAge: 300000
-
 # LSN check configuration for replication failover auto mode (in milliseconds)
 # See: https://docs.pgdog.dev/features/load-balancer/replication-failover/
 # lsnCheckDelay: 0        # Set to 0 to start LSN monitoring immediately


### PR DESCRIPTION
The application version being deployed is usually kept in the Chart.yaml and used as the default image.tag version is one is not supplied. This adds the appVersion to the Chart.yaml and updates the tag of the Docker image to use this appVersion by default.

Closes #48 