### PR TITLE
feat: add image digest as value to pass

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
         - name: pgdog
           {{- if .Values.image.name }}
           image: {{ .Values.image.name }}
+          {{- else if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,9 @@ image:
   repository: ghcr.io/pgdogdev/pgdog
   # tag is the Docker image tag (defaults to Chart appVersion if not specified)
   tag: ""
+  # digest is the image digest (overrides tag when specified)
+  # Example: digest: sha256:abc123def456...
+  digest: ""
   # pullPolicy specifies when to use cached version of the image.
   pullPolicy: IfNotPresent
   # name is the full image name (DEPRECATED: use repository and tag)


### PR DESCRIPTION
There was no way to pass the image digest due to the way the image was constructed in the deployment file. This adds an `image.digest` field for specifying the digest instead of a tag.

Closes #49 