### PR TITLE
Add query_parser enum config, deprecate query_parser_enabled

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -40,8 +40,12 @@ data:
         {{- end}}
         shutdown_timeout          =   {{ .Values.shutdownTimeout | default "60_000" }}
         prepared_statements       =   {{ .Values.preparedStatements | default "extended" | quote }}
+        {{- with .Values.queryParser }}
+        query_parser              =   {{ . | quote }}
+        {{- else }}
         {{- with .Values.queryParserEnabled }}
         query_parser_enabled      =   {{ . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.preparedStatementsLimit }}
         prepared_statements_limit =   {{ .Values.preparedStatementsLimit }}

--- a/values.yaml
+++ b/values.yaml
@@ -329,3 +329,11 @@ queryStats:
 # tcpTime: 7200
 # tcpInterval: 75
 # tcpRetries: 9
+
+# Query parser configuration
+# queryParser controls whether the query parser is enabled
+# Valid values: "auto", "on", "off"
+# queryParser: "auto"
+
+# queryParserEnabled is DEPRECATED - use queryParser instead
+# queryParserEnabled: true


### PR DESCRIPTION
This adds the new `query_parser` enum value to the helm chart from https://github.com/pgdogdev/pgdog/pull/693/changes

If hat value is set, we will prioritize that, otherwise fallback to if the previous configuration was set.