### PR TITLE
Add support for deployment annotations

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
   name: {{ include "pgdog.fullname" . }}
   labels:
     {{- include "pgdog.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.statefulSet.enabled }}
   serviceName: {{ include "pgdog.fullname" . }}-headless

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,9 @@ fullnameOverride: ""
 labels: {}
 selectorLabels: {}
 
+# allows adding custom annotations to the deployment
+annotations: {}
+
 # allows adding custom annotations to the pods
 podAnnotations: {}
 


### PR DESCRIPTION
This PR adds support for deployment annotations.

One possible use case is to set [reloader](https://github.com/stakater/Reloader) annotations to allow automatic reload of pods after configuration changes (eg. https://github.com/pgdogdev/helm/issues/15).