### PR TITLE
feat: support serverAuth, imagePullSecrets and podLabels

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,12 +26,13 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  {{- include "pgdog.imagePullSecrets" . | nindent 2 }}
   template:
     metadata:
       labels:
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "pgdog.selectorLabels" . | nindent 8 }}
-        {{- include "pgdog.podLabels" . | nindent 8 }}
       {{- if or .Values.restartOnConfigChange .Values.podAnnotations }}
       annotations:
         {{- if .Values.restartOnConfigChange }}
@@ -53,6 +54,10 @@ spec:
       {{- end }}
       {{- with .Values.extraInitContainers }}
       initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,10 +26,12 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+  {{- include "pgdog.imagePullSecrets" . | nindent 2 }}
   template:
     metadata:
       labels:
         {{- include "pgdog.selectorLabels" . | nindent 8 }}
+        {{- include "pgdog.podLabels" . | nindent 8 }}
       {{- if or .Values.restartOnConfigChange .Values.podAnnotations }}
       annotations:
         {{- if .Values.restartOnConfigChange }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -38,6 +38,9 @@ read_only = {{ .readOnly }}
 {{- if .serverLifetime }}
 server_lifetime = {{ .serverLifetime }}
 {{- end }}
+{{- if .serverAuth }}
+server_auth = {{ .serverAuth | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,8 @@ selectorLabels: {}
 # allows adding custom annotations to the deployment
 annotations: {}
 
+# allows adding custom labels to the pods
+podLabels: {}
 # allows adding custom annotations to the pods
 podAnnotations: {}
 
@@ -27,6 +29,15 @@ podAnnotations: {}
 # clusterName identifies the Kubernetes cluster (optional)
 # When set, this will be added as a label to all Prometheus metrics
 # clusterName: ""
+
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## e.g:
+## imagePullSecrets:
+##   - name: regcred
+##
+imagePullSecrets: []
 
 # image contains the Docker image properties.
 image:


### PR DESCRIPTION
Hi there,

This PR introduces some configuration enhancements to the Helm chart:
- imagePullSecrets: Allows the deployment to pull images from private container registries.
- podLabels: Provides the ability to inject custom labels for better resource tracking / service mesh integration / Workload Identity.
- serverAuth: Adds user-level configuration for server authentication.

These changes provide more flexibility for custom environments and security requirements