### PR TITLE
feat: add support for regex_parser_limit

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.47
-appVersion: "0.1.32"
+version: v0.48
+appVersion: "0.1.37"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -94,6 +94,9 @@ data:
         {{- if .Values.reshardingCopyFormat }}
         resharding_copy_format    =   {{ .Values.reshardingCopyFormat | quote }}
         {{- end }}
+        {{- if .Values.reshardingParallelCopies }}
+        resharding_parallel_copies =   {{ include "pgdog.intval" .Values.reshardingParallelCopies }}
+        {{- end }}
         {{- if hasKey .Values "reloadSchemaOnDdl" }}
         reload_schema_on_ddl      =   {{ .Values.reloadSchemaOnDdl }}
         {{- end }}
@@ -124,6 +127,8 @@ data:
         server_lifetime = {{ include "pgdog.intval" (.Values.serverLifetime | default 86400000) }}
         log_connections = {{ .Values.logConnections | default "true" }}
         log_disconnections = {{ .Values.logDisconnections | default "true" }}
+        log_dedup_threshold = {{ include "pgdog.intval" (.Values.logDedupThreshold | default 0) }}
+        log_dedup_window = {{ include "pgdog.intval" (.Values.logDedupWindow | default 0) }}
         {{- if .Values.statsPeriod }}
         stats_period              =   {{ include "pgdog.intval" .Values.statsPeriod }}
         {{- end }}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -58,6 +58,9 @@ data:
         {{- if .Values.queryParserEngine }}
         query_parser_engine       =   {{ .Values.queryParserEngine | quote }}
         {{- end }}
+        {{- if .Values.regexParserLimit }}
+        regex_parser_limit        =   {{ include "pgdog.intval" .Values.regexParserLimit }}
+        {{- end }}
         {{- if .Values.preparedStatementsLimit }}
         prepared_statements_limit =   {{ include "pgdog.intval" .Values.preparedStatementsLimit }}
         {{- end}}

--- a/test/values-full.yaml
+++ b/test/values-full.yaml
@@ -5,6 +5,7 @@ env:
   - name: RUST_LOG
     value: trace
 queryParserEngine: "pg_query_raw"
+regexParserLimit: 1000
 
 # Sharding settings
 twoPhaseCommit: true

--- a/test/values-full.yaml
+++ b/test/values-full.yaml
@@ -13,6 +13,7 @@ twoPhaseCommitAuto: false
 systemCatalogs: omnisharded_sticky
 omnishardedSticky: true
 reshardingCopyFormat: binary
+reshardingParallelCopies: 1
 reloadSchemaOnDdl: true
 
 memoryNetBuffer: 8192

--- a/values.yaml
+++ b/values.yaml
@@ -524,8 +524,8 @@ control:
 # memoryStackSize: 2097152
 
 # Query parser configuration
-# queryParser controls whether the query parser is enabled
-# Valid values: "auto", "on", "off"
+# queryParser controls whether the query parser and which features are enabled
+# Valid values: "auto", "on", "off", "session_control", "session_control_and_locks"
 # queryParser: "auto"
 
 # queryParserEngine specifies which query parser engine to use
@@ -533,6 +533,10 @@ control:
 
 # queryParserEnabled is DEPRECATED - use queryParser instead
 # queryParserEnabled: true
+
+# regexParserLimit specifies the maximum number of characters in a query that the regex parser
+# will inspect. Only applies when queryParser is "session_control" or "session_control_and_locks"
+# regexParserLimit: 1000
 
 # Prometheus Collector configuration
 # Deploys a standalone Prometheus instance that collects metrics from all pgdog pods


### PR DESCRIPTION
- Bumps pgdog version to next (I used 0.1.37 but I will confirm once the version is released).
- Bumps the helm chart version
- Adds support for `regex_parser_limit`: https://github.com/pgdogdev/pgdog/commit/2cd79bf08d4d22a2c9e862e37d91e80a90aa3309
- Adds support for resharding_parallel_copies: https://github.com/pgdogdev/pgdog/commit/693f7c9374dba3aae2aa61bff906e14655dde99f#diff-95d8980d368201c3e8dfabcd9b28abda88a53c6e415f6b895bd151de02723682
- Adds support for `log_dedup_window` and `log_dedup_threshold`: https://github.com/pgdogdev/pgdog/commit/50797ac5312390251a6fd623fe4228260959bac4