### PR TITLE
fix: make log dedup settings optional

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.52
+version: v0.53
 appVersion: "0.1.37"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -134,8 +134,12 @@ data:
         server_lifetime = {{ include "pgdog.intval" (.Values.serverLifetime | default 86400000) }}
         log_connections = {{ .Values.logConnections | default "true" }}
         log_disconnections = {{ .Values.logDisconnections | default "true" }}
-        log_dedup_threshold = {{ include "pgdog.intval" (.Values.logDedupThreshold | default 0) }}
-        log_dedup_window = {{ include "pgdog.intval" (.Values.logDedupWindow | default 0) }}
+        {{- if .Values.logDedupThreshold }}
+        log_dedup_threshold = {{ include "pgdog.intval" .Values.logDedupThreshold }}
+        {{- end }}
+        {{- if .Values.logDedupWindow }}
+        log_dedup_window = {{ include "pgdog.intval" .Values.logDedupWindow }}
+        {{- end }}
         {{- if .Values.statsPeriod }}
         stats_period              =   {{ include "pgdog.intval" .Values.statsPeriod }}
         {{- end }}


### PR DESCRIPTION
We should really be careful with adding new settings like this. Charts become backwards-incompatible.