### PR TITLE
feat: adding ability to configure securityContext + fix 

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -58,10 +58,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- with .Values.podSecurityContext }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       containers:
         - name: pgdog
           {{- if .Values.image.name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,9 +43,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "pgdog.serviceAccountName" . }}
-      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
@@ -60,6 +58,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- with .Values.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: pgdog
           {{- if .Values.image.name }}
@@ -131,6 +133,10 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.prometheusPort }}
         - name: prom
           image: prom/prometheus

--- a/values.yaml
+++ b/values.yaml
@@ -644,3 +644,6 @@ prometheusCollector:
   tolerations: []
   # affinity rules for pod scheduling
   affinity: {}
+
+securityContext: {}
+podSecurityContext: {}


### PR DESCRIPTION
## Changes:
- Add support for configuring `podSecurityContext` / `securityContext` (both pod-level and container-level) via Helm values
- Fix `serviceAccountName` not being set on the pod when `serviceAccount.create=false` (was was silently dropped from the pod spec, causing the pod to fall back to the `default` service account)