### PR TITLE
feat: add `noCpuLimits` option to allow not setting CPU limits

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.54
+version: v0.55
 appVersion: "0.1.37"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -122,3 +122,26 @@ as scientific notation (e.g. 8.64e+07). TOML rejects this.
 {{- define "pgdog.intval" -}}
 {{- if kindIs "string" . -}}{{ . }}{{- else -}}{{ int64 . }}{{- end -}}
 {{- end -}}
+
+{{/*
+Render a resources block, omitting CPU limits when noCpuLimits is true.
+Call as: include "pgdog.resources" (dict "resources" .Values.resources "noCpuLimits" .Values.noCpuLimits)
+*/}}
+{{- define "pgdog.resources" -}}
+{{- $res := .resources -}}
+{{- if $res -}}
+resources:
+  {{- if $res.requests }}
+  requests:
+    {{- toYaml $res.requests | nindent 4 }}
+  {{- end }}
+  {{- $limits := $res.limits }}
+  {{- if and .noCpuLimits $limits }}
+  {{- $limits = omit $limits "cpu" }}
+  {{- end }}
+  {{- if $limits }}
+  limits:
+    {{- toYaml $limits | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -99,10 +99,7 @@ spec:
               sleep:
                 seconds: {{ .Values.preStopSleepSeconds }}
           {{- end }}
-          {{- if .Values.resources }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- end }}
+          {{- include "pgdog.resources" (dict "resources" .Values.resources "noCpuLimits" .Values.noCpuLimits) | nindent 10 }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
@@ -171,10 +168,7 @@ spec:
           ports:
             - name: prom
               containerPort: {{ .Values.prometheusPort }}
-          {{- if .Values.prometheusResources }}
-          resources:
-            {{- toYaml .Values.prometheusResources | nindent 12 }}
-          {{- end }}
+          {{- include "pgdog.resources" (dict "resources" .Values.prometheusResources "noCpuLimits" .Values.noCpuLimits) | nindent 10 }}
           volumeMounts:
             - name: prom
               mountPath: /etc/prom

--- a/values.yaml
+++ b/values.yaml
@@ -130,6 +130,10 @@ extraVolumes: []
 #     mountPath: /pki
 extraVolumeMounts: []
 
+# noCpuLimits removes CPU limits from containers so they can use idle CPU on the host.
+# Memory limits are still applied. CPU requests are preserved for scheduling.
+noCpuLimits: false
+
 # resources define resource requests and limits for the pgdog container
 # Note: requests and limits are set to the same values for Guaranteed QoS
 # Ratio: 1GB memory per 1 CPU (1000m CPU = 1Gi memory)


### PR DESCRIPTION
so that containers can use idle CPU on the host.
See https://home.robusta.dev/blog/stop-using-cpu-limits

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
