### PR TITLE
fix: type error in restartOnConfigChange

### DIFF
--- a/scripts/schema-overrides.yaml
+++ b/scripts/schema-overrides.yaml
@@ -19,6 +19,7 @@ podLabels:
 podAnnotations:
   description: Custom annotations for pods
 restartOnConfigChange:
+  type: boolean
   description: Trigger rolling restart when pgdog config changes
 clusterName:
   description: Kubernetes cluster name, added as a label to Prometheus metrics

--- a/values.schema.json
+++ b/values.schema.json
@@ -1200,7 +1200,7 @@
       "description": "Resource requests and limits for the pgdog container"
     },
     "restartOnConfigChange": {
-      "type": "string",
+      "type": "boolean",
       "description": "Trigger rolling restart when pgdog config changes"
     },
     "rewrite": {


### PR DESCRIPTION
Fixed a type error in `restartOnConfigChange`. Any reference to this field in this repository now implies that its type is `boolean` rather than `string`. So, the override table and generated artifacts have been updated.