### PR TITLE
Fix type inference for fields with intermediate pipe filters

### DIFF
--- a/scripts/generate-schema.py
+++ b/scripts/generate-schema.py
@@ -40,18 +40,18 @@ VALUES_RE = re.compile(r"\.Values\.([a-zA-Z_][\w]*(?:\.[a-zA-Z_][\w]*)*)")
 # Template `if .Values.X` is a truthiness check, not a type indicator.
 CONTEXT_PATTERNS = [
     # pgdog.intval → integer (accepts int or underscore-separated string)
-    (re.compile(r'include\s+"pgdog\.intval".*\.Values\.{path}'), "integer"),
-    (re.compile(r'\.Values\.{path}.*\|\s*int'), "integer"),
+    (re.compile(r'include\s+"pgdog\.intval".*\.Values\.{path}\b'), "integer"),
+    (re.compile(r'\.Values\.{path}\b.*\|\s*int\b'), "integer"),
     # | toYaml / with .Values.X → object
-    (re.compile(r"\.Values\.{path}\s*\|\s*toYaml"), "object"),
-    (re.compile(r"toYaml\s+\.Values\.{path}"), "object"),
-    (re.compile(r"with\s+\.Values\.{path}\s"), "object"),
+    (re.compile(r"\.Values\.{path}\b\s*\|\s*toYaml"), "object"),
+    (re.compile(r"toYaml\s+\.Values\.{path}\b"), "object"),
+    (re.compile(r"with\s+\.Values\.{path}\b\s"), "object"),
     # | toToml → array
-    (re.compile(r"\.Values\.{path}\s*\|\s*toToml"), "array"),
+    (re.compile(r"\.Values\.{path}\b\s*\|\s*toToml"), "array"),
     # range .Values.X → array
-    (re.compile(r"range\s+\.Values\.{path}"), "array"),
-    # | quote → string
-    (re.compile(r"\.Values\.{path}\s*\|\s*quote"), "string"),
+    (re.compile(r"range\s+\.Values\.{path}\b"), "array"),
+    # | quote → string (allow intermediate filters like `| default "foo" | quote`)
+    (re.compile(r"\.Values\.{path}\b[^}]*\|\s*quote"), "string"),
 ]
 
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -650,6 +650,14 @@
         "off"
       ]
     },
+    "logMinDurationParse": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "logQuerySampleLength": {
+      "type": "integer",
+      "minimum": 0
+    },
     "lsnCheckDelay": {
       "type": "integer",
       "minimum": 0
@@ -901,8 +909,7 @@
       "description": "Delay before stopping container to allow endpoint updates"
     },
     "preparedStatements": {
-      "type": "integer",
-      "minimum": 0
+      "type": "string"
     },
     "preparedStatementsLimit": {
       "type": "integer",
@@ -1167,14 +1174,6 @@
     "readinessProbe": {
       "type": "object",
       "description": "Container readiness probe configuration"
-    },
-    "logMinDurationParse": {
-      "type": "integer",
-      "minimum": 0
-    },
-    "logQuerySampleLength": {
-      "type": "integer",
-      "minimum": 0
     },
     "regexParserLimit": {
       "type": "integer",
@@ -1491,8 +1490,7 @@
       }
     },
     "twoPhaseCommit": {
-      "type": "boolean",
-      "minimum": 0
+      "type": "boolean"
     },
     "twoPhaseCommitAuto": {
       "type": "boolean"


### PR DESCRIPTION
- Add word boundaries to all context patterns to prevent substring matches (e.g. preparedStatements matching preparedStatementsLimit).
-  Broaden the quote pattern to allow intermediate filters like \`| default "foo" | quote\`.