### PR TITLE
feat(jitter): adds support of serverLifetimeJitter

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.62
+version: v0.63
 appVersion: "0.1.41"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -162,6 +162,7 @@ data:
         openmetrics_port = {{ include "pgdog.intval" (.Values.openMetricsPort | default 9090) }}
         openmetrics_namespace = {{ .Values.openMetricsNamespace | default "pgdog_" | quote }}
         server_lifetime = {{ include "pgdog.intval" (.Values.serverLifetime | default 86400000) }}
+        server_lifetime_jitter = {{ include "pgdog.intval" (.Values.serverLifetimeJitter | default 0) }}
         log_connections = {{ hasKey .Values "logConnections" | ternary .Values.logConnections "true" }}
         log_disconnections = {{ hasKey .Values "logDisconnections" | ternary .Values.logDisconnections "true" }}
         {{- if .Values.logDedupThreshold }}

--- a/test/values-timeouts.yaml
+++ b/test/values-timeouts.yaml
@@ -11,6 +11,7 @@ checkoutTimeout: 10_000
 idleTimeout: 300_000
 clientIdleTimeout: 600_000
 clientLoginTimeout: 30_000
+serverLifetimeJitter: 60_000
 statsPeriod: 30_000
 lsnCheckDelay: 1_000
 lsnCheckInterval: 10_000

--- a/values.yaml
+++ b/values.yaml
@@ -189,6 +189,21 @@ logFormat: text
 # Defaults to `info`.
 logLevel: "info"
 
+# serverLifetime is the maximum amount of time (in milliseconds) a server
+# connection is allowed to exist. Connections exceeding this limit are closed
+# once they are checked back into the pool.
+# Defaults to 86400000 (24h).
+# serverLifetime: 86400000
+
+# serverLifetimeJitter is the maximum random adjustment (in milliseconds)
+# applied to serverLifetime per backend connection. Each connection's effective
+# lifetime is sampled uniformly from
+# [serverLifetime - jitter, serverLifetime + jitter] once at creation. This
+# breaks up synchronized retirement of connection cohorts that opened together
+# (e.g. during a traffic ramp).
+# Defaults to 0 (no jitter).
+# serverLifetimeJitter: 0
+
 # Admin password
 # adminPassword: change-me
 


### PR DESCRIPTION
# Description

Adds support of `serverLifetimeJitter`. 
https://docs.pgdog.dev/configuration/pgdog.toml/general/#server_lifetime_jitter