### PR TITLE
v0.1.46

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.68
-appVersion: "0.1.44"
+version: v0.69
+appVersion: "0.1.46"


### PR DESCRIPTION
Bumps `appVersion` to `0.1.46` (and chart `version` to `v0.69`, per the repo convention of bumping the chart version on every change).

The image tag defaults to `.Chart.AppVersion`, so this rolls the default pgdog image to `0.1.46`. No other files reference the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)