### PR TITLE
feat: support externalTrafficPolicy / internalTrafficPolicy on the Service

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -35,6 +35,12 @@ spec:
   {{- if .Values.service.trafficDistribution }}
   trafficDistribution: {{ .Values.service.trafficDistribution | quote }}
   {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     - name: pgdog
       protocol: TCP

--- a/test/values-traffic-policy.yaml
+++ b/test/values-traffic-policy.yaml
@@ -1,0 +1,5 @@
+# Test externalTrafficPolicy / internalTrafficPolicy rendering
+service:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster

--- a/values.yaml
+++ b/values.yaml
@@ -317,6 +317,16 @@ service:
   # (PreferClose, PreferSameZone, PreferSameNode)
   # see https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution for more details.
   trafficDistribution: ""
+  # externalTrafficPolicy controls how NodePort and LoadBalancer services
+  # route external traffic (Cluster or Local). Local restricts load-balancer
+  # backends to nodes running pgdog pods (avoiding an extra hop through
+  # non-backend nodes) and preserves client source IPs.
+  # see https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy for more details.
+  externalTrafficPolicy: ""
+  # internalTrafficPolicy controls how in-cluster traffic to the service is
+  # routed (Cluster or Local).
+  # see https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy for more details.
+  internalTrafficPolicy: ""
   # aws configures AWS Load Balancer Controller annotations
   # When enabled, service type is automatically set to LoadBalancer
   aws:


### PR DESCRIPTION
## What

Adds two optional values to the Service, rendered only when set (same pattern as `trafficDistribution`):

- `service.externalTrafficPolicy` — `Cluster` or `Local`
- `service.internalTrafficPolicy` — `Cluster` or `Local`

Also adds `test/values-traffic-policy.yaml`, which the existing `test/test.sh` loop picks up; the full suite passes with strict kubeconform validation.

## Why

When pgdog is exposed through a `LoadBalancer` Service, the default `externalTrafficPolicy: Cluster` makes every cluster node an LB backend, with kube-proxy relaying connections that land on pod-less nodes. For a connection pooler holding long-lived Postgres sessions this puts every node in the cluster on the data path: we run pgdog on GKE Autopilot, where routine node recycling was killing established client connections relayed through unrelated dying nodes (`ConnectionDoesNotExistError` on long-held sessions, `ConnectionRefusedError` against booting/draining nodes), while pgdog itself was healthy with clean logs.

`externalTrafficPolicy: Local` restricts LB backends to the nodes actually running pgdog pods, taking unrelated node churn off the data path (and preserving client source IPs). The chart currently offers no way to set it, so we were patching the Service after every `helm upgrade`. `internalTrafficPolicy` is included as the natural sibling for in-cluster clients.

Both fields default to empty, so existing rendered output is unchanged unless a user opts in.