### PR TITLE
fix: default query_parsers engine to pg_query_protobuf

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.70
+version: v0.71
 appVersion: "0.1.47"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -357,9 +357,7 @@ data:
         [[query_parsers]]
         database = {{ .database | quote }}
         level = {{ .level | quote }}
-        {{- if hasKey . "engine" }}
-        engine = {{ .engine | quote }}
-        {{- end }}
+        engine = {{ .engine | default "pg_query_protobuf" | quote }}
         {{- end }}
 
         {{- range .Values.shardedSchemas }}

--- a/test/values-pgdog-config-extras.yaml
+++ b/test/values-pgdog-config-extras.yaml
@@ -67,3 +67,6 @@ queryParsers:
   - database: primary
     level: "off"
     engine: pg_query_raw
+  # engine omitted: should render the pg_query_protobuf default
+  - database: primary_mirror
+    level: "session_control_and_locks"

--- a/values.yaml
+++ b/values.yaml
@@ -228,7 +228,9 @@ users: []
 mirrors: []
 
 # queryParsers contains per-database query parser settings in pgdog.toml.
-# Each entry requires: database and level; engine is optional.
+# Each entry requires: database and level; engine is optional and
+# defaults to "pg_query_protobuf" (pgdog requires the field in
+# [[query_parsers]] entries and fails to start without it).
 # Example:
 # queryParsers:
 #   - database: "prod"


### PR DESCRIPTION
pgdog requires the `engine` field in `[[query_parsers]]` entries and fails to start when it is missing (the `QueryParser` config struct has no serde default for the field), but the chart only rendered `engine` when set and documented it as optional.

Always render `engine`, defaulting to `pg_query_protobuf` (pgdog's default engine), so omitting it in `queryParsers` values no longer produces a config pgdog can't parse.

- `templates/config.yaml`: render `engine` unconditionally with a `pg_query_protobuf` default
- `test/values-pgdog-config-extras.yaml`: add an entry without `engine` to exercise the default
- `values.yaml`: document the default
- bump chart to v0.71

Verified with `test/test.sh` (all passing) — rendered output:

```toml
[[query_parsers]]
database = "primary"
level = "off"
engine = "pg_query_raw"
[[query_parsers]]
database = "primary_mirror"
level = "session_control_and_locks"
engine = "pg_query_protobuf"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)