### PR TITLE
FEAT: workers auto match CPU limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ logFormat: json
 logLevel: info
 ```
 
+`workers` also accepts `auto`, which sizes the tokio runtime to the
+container's CPU allocation: 2 workers per vCPU (PgDog's recommendation),
+rounded up, derived from `resources.limits.cpu` — or
+`resources.requests.cpu` when `noCpuLimits` is true. Changing it
+requires a pod restart.
+
 ### Docker Image
 
 By default, the chart uses the `appVersion` from `Chart.yaml` as the image

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -120,6 +120,35 @@ Call as: include "pgdog.flexlist" .values
 {{- end -}}
 
 {{/*
+Render the workers setting.
+"auto" derives it from container CPU resources: 2 workers per vCPU
+(pgdog's recommendation), rounded up. Uses resources.limits.cpu, or
+resources.requests.cpu when noCpuLimits is true (no CPU limit applies then).
+Any other value renders as-is via pgdog.intval.
+*/}}
+{{- define "pgdog.workers" -}}
+{{- if eq (toString .Values.workers) "auto" -}}
+{{- $res := .Values.resources | default dict -}}
+{{- $limits := $res.limits | default dict -}}
+{{- $requests := $res.requests | default dict -}}
+{{- $cpu := ternary $requests.cpu ($limits.cpu | default $requests.cpu) (.Values.noCpuLimits | default false) -}}
+{{- if not $cpu -}}
+{{- fail "workers: auto requires resources.limits.cpu (or resources.requests.cpu when noCpuLimits is true)" -}}
+{{- end -}}
+{{- $cpu = toString $cpu -}}
+{{- $cores := 0.0 -}}
+{{- if hasSuffix "m" $cpu -}}
+{{- $cores = divf (float64 (trimSuffix "m" $cpu)) 1000 -}}
+{{- else -}}
+{{- $cores = float64 $cpu -}}
+{{- end -}}
+{{- max 1 (int (ceil (mulf 2 $cores))) -}}
+{{- else -}}
+{{- include "pgdog.intval" .Values.workers -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Render a resources block, omitting CPU limits when noCpuLimits is true.
 Call as: include "pgdog.resources" (dict "resources" .Values.resources "noCpuLimits" .Values.noCpuLimits)
 */}}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -10,7 +10,7 @@ data:
         port                      =   {{ include "pgdog.intval" .Values.port }}
         {{- end }}
         {{- if hasKey .Values "workers" }}
-        workers                   =   {{ include "pgdog.intval" .Values.workers }}
+        workers                   =   {{ include "pgdog.workers" . }}
         {{- end }}
         {{- if hasKey .Values "defaultPoolSize" }}
         default_pool_size         =   {{ include "pgdog.intval" .Values.defaultPoolSize }}

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,5 +37,30 @@ else
   exit 1
 fi
 
+# Validate workers: auto derives from CPU resources
+echo ""
+echo "==> Validating workers: auto derivation..."
+workers_line() {
+  helm template test-release "$CHART_DIR" -f "$TEST_DIR/values-workers-auto.yaml" "$@" \
+    | yq -r 'select(.kind == "ConfigMap" and .metadata.name == "test-release-pgdog") | .data["pgdog.toml"]' \
+    | grep '^workers'
+}
+
+if workers_line | grep -Eq '= +4$'; then
+  echo "  workers derived from limits.cpu (2000m -> 4)"
+else
+  echo "  FAIL: expected workers = 4 from limits.cpu 2000m"
+  echo "  Got: $(workers_line)"
+  exit 1
+fi
+
+if workers_line --set noCpuLimits=true | grep -Eq '= +3$'; then
+  echo "  workers derived from requests.cpu with noCpuLimits (1500m -> 3)"
+else
+  echo "  FAIL: expected workers = 3 from requests.cpu 1500m with noCpuLimits"
+  echo "  Got: $(workers_line --set noCpuLimits=true)"
+  exit 1
+fi
+
 echo ""
 echo "==> All tests passed!"

--- a/test/values-workers-auto.yaml
+++ b/test/values-workers-auto.yaml
@@ -1,0 +1,8 @@
+workers: auto
+resources:
+  requests:
+    cpu: 1500m
+    memory: 2Gi
+  limits:
+    cpu: 2000m
+    memory: 2Gi

--- a/values.yaml
+++ b/values.yaml
@@ -136,6 +136,13 @@ extraVolumeMounts: []
 # Memory limits are still applied. CPU requests are preserved for scheduling.
 noCpuLimits: false
 
+# workers sets the number of tokio worker threads ([general] workers in pgdog.toml).
+# Set to "auto" to derive it from CPU resources: 2 workers per vCPU (pgdog's
+# recommendation), rounded up, based on resources.limits.cpu — or
+# resources.requests.cpu when noCpuLimits is true. Omit to use pgdog's
+# built-in default (2). Requires a pod restart to take effect.
+# workers: auto
+
 # resources define resource requests and limits for the pgdog container
 # Note: requests and limits are set to the same values for Guaranteed QoS
 # Ratio: 1GB memory per 1 CPU (1000m CPU = 1Gi memory)


### PR DESCRIPTION
`workers: auto` to derive workers from cpu limits