### PR TITLE
feat: create wal dir, don't use mount point

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.71
-appVersion: "0.1.47"
+version: v0.72
+appVersion: "0.1.50"

--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ statefulSet:
 ```
 
 The StatefulSet creates one `ReadWriteOnce` persistent volume claim per replica
-and mounts it at `/var/lib/pgdog`. The generated PgDog configuration sets
-`two_phase_commit_wal_dir` to that mount point automatically. An explicit
-`twoPhaseCommitWalDir` value takes precedence.
+and mounts it at `/var/lib/pgdog`. Before PgDog starts, an init container creates
+`/var/lib/pgdog/wal` on the volume. The generated PgDog configuration sets
+`two_phase_commit_wal_dir` to that directory automatically. An explicit
+`twoPhaseCommitWalDir` value still takes precedence.
 
 The claims use the cluster's default `StorageClass`. Ensure one is configured
 for dynamic provisioning before enabling `walPvc`. This option has no effect

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -152,7 +152,7 @@ data:
         {{- if hasKey .Values "twoPhaseCommitWalDir" }}
         two_phase_commit_wal_dir  =   {{ .Values.twoPhaseCommitWalDir | quote }}
         {{- else if and .Values.statefulSet.enabled .Values.statefulSet.walPvc.enabled }}
-        two_phase_commit_wal_dir  =   "/var/lib/pgdog"
+        two_phase_commit_wal_dir  =   "/var/lib/pgdog/wal"
         {{- end }}
         {{- if hasKey .Values "twoPhaseCommitWalSegmentSize" }}
         two_phase_commit_wal_segment_size      =   {{ include "pgdog.intval" .Values.twoPhaseCommitWalSegmentSize }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,9 +52,26 @@ spec:
       {{- else }}
       terminationGracePeriodSeconds: {{ add (div (default 60000 .Values.shutdownTimeout | int64) 1000) 5 }}
       {{- end }}
-      {{- with .Values.extraInitContainers }}
+      {{- if or (and .Values.statefulSet.enabled .Values.statefulSet.walPvc.enabled) .Values.extraInitContainers }}
       initContainers:
+        {{- if and .Values.statefulSet.enabled .Values.statefulSet.walPvc.enabled }}
+        - name: create-wal-directory
+          {{- if .Values.image.name }}
+          image: {{ .Values.image.name }}
+          {{- else if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["mkdir", "-p", "/var/lib/pgdog/wal"]
+          volumeMounts:
+            - name: wal
+              mountPath: /var/lib/pgdog
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -90,8 +90,8 @@ statefulSet:
   # enabled switches from Deployment to StatefulSet
   enabled: false
   # walPvc creates one persistent volume claim per StatefulSet pod.
-  # The volume is mounted at /var/lib/pgdog. When enabled,
-  # twoPhaseCommitWalDir defaults to this mount point.
+  # The volume is mounted at /var/lib/pgdog. An init container creates the
+  # /var/lib/pgdog/wal directory, which is used by twoPhaseCommitWalDir.
   walPvc:
     enabled: false
     size: 1Gi


### PR DESCRIPTION
Don't use the mount point as the WAL dir, use init container to create a `/var/lib/pgdog/wal` directory.