### PR TITLE
feat: query_cache_memory_limit and query_cache_idle_timeout options

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: pgdog
-version: v0.75
+version: v0.76
 appVersion: "v0.1.52"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -123,6 +123,12 @@ data:
         {{- if hasKey .Values "queryCacheLimit" }}
         query_cache_limit         =   {{ include "pgdog.intval" .Values.queryCacheLimit }}
         {{- end }}
+        {{- if hasKey .Values "queryCacheMemoryLimit" }}
+        query_cache_memory_limit  =   {{ include "pgdog.intval" .Values.queryCacheMemoryLimit }}
+        {{- end }}
+        {{- if hasKey .Values "queryCacheIdleTimeout" }}
+        query_cache_idle_timeout  =   {{ include "pgdog.intval" .Values.queryCacheIdleTimeout }}
+        {{- end }}
         {{- if hasKey .Values "passthroughAuth" }}
         passthrough_auth          =   {{ .Values.passthroughAuth | quote }}
         {{- end }}

--- a/test/values-full.yaml
+++ b/test/values-full.yaml
@@ -17,6 +17,8 @@ readWriteSplit: include_primary
 preparedStatements: extended
 preparedStatementsLimit: 1000
 queryCacheLimit: 500
+queryCacheMemoryLimit: 1_073_741_824
+queryCacheIdleTimeout: 600_000
 passthroughAuth: disabled
 connectAttempts: 2
 connectAttemptDelay: 100

--- a/test/values-pgdog-config-extras.yaml
+++ b/test/values-pgdog-config-extras.yaml
@@ -2,7 +2,8 @@
 # Covers: ban_replica_lag*, 2PC WAL persistence, resharding copy retries,
 # query_log, rewrite_shard_key_updates, unique_id_*, cutover_*,
 # tcp user_timeout/congestion_control, mirroring queue_length/level,
-# query_parsers table, database lb_weight/resharding_only, multi_tenant, otel.
+# query_parsers table, database lb_weight/resharding_only, multi_tenant, otel,
+# query_cache_memory_limit/query_cache_idle_timeout.
 
 banReplicaLag: 60_000
 banReplicaLagBytes: 10_000_000
@@ -67,3 +68,6 @@ queryParsers:
   - database: primary
     level: "off"
     engine: pg_query_raw
+
+queryCacheMemoryLimit: 1_073_741_824
+queryCacheIdleTimeout: 600_000

--- a/values.yaml
+++ b/values.yaml
@@ -620,6 +620,17 @@ rdsCertificateBundle:
 # memoryMessageBuffer: 8192
 # memoryStackSize: 2097152
 
+# Query cache configuration (optional)
+# queryCacheMemoryLimit is the memory budget (in bytes) for the query (AST) cache;
+# least recently used entries are evicted once the summed entry size exceeds it.
+# 0 disables the memory cap.
+# queryCacheMemoryLimit: 1073741824
+
+# queryCacheIdleTimeout is the idle timeout (in milliseconds) for query cache
+# entries; entries not accessed within this window are dropped by the
+# maintenance sweep. 0 disables idle expiry.
+# queryCacheIdleTimeout: 600000
+
 # Query parser configuration
 # queryParser controls whether the query parser and which features are enabled
 # Valid values: "auto", "on", "off", "session_control", "session_control_and_locks"


### PR DESCRIPTION
Renders the two `[general]` options added in pgdogdev/pgdog#1266 into `pgdog.toml`:

- `queryCacheMemoryLimit` → `query_cache_memory_limit` (bytes)
- `queryCacheIdleTimeout` → `query_cache_idle_timeout` (milliseconds)

Both are optional and omitted from the config unless set, so existing values are unaffected. Until that PR ships in a release, the only way to set these is the `PGDOG_QUERY_CACHE_MEMORY_LIMIT` / `PGDOG_QUERY_CACHE_IDLE_TIMEOUT` env variables on the container.

Covered in `test/values-full.yaml` and `test/values-pgdog-config-extras.yaml`; `test/test.sh` passes.

Draft until pgdogdev/pgdog#1266 is merged and released.
