### PR TITLE
fix: restart when rendered users change

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,39 @@ constraints can be set with `topologySpreadConstraints`.
 
 ### Config Change Restarts
 
-By default, ConfigMap changes are not automatically picked up by
-running pods. Enable `restartOnConfigChange` to trigger a rolling
-restart whenever the rendered config changes:
+By default, ConfigMap and Secret changes are not automatically picked up by
+running pods. Enable `restartOnConfigChange` to trigger a rolling restart
+whenever the chart-rendered `pgdog.toml` or `users.toml` changes:
 
 ```yaml
 restartOnConfigChange: true
 ```
 
-This injects a `checksum/config` pod annotation that changes when the
-config template output changes, causing Kubernetes to roll the pods.
+This injects `checksum/config` and `checksum/users` pod annotations for the
+files rendered by the chart, causing Kubernetes to roll the pods when either
+file changes. The option is disabled by default because a rollout interrupts
+client connections; leave it disabled if you reload PgDog another way.
+
+Helm cannot checksum the contents of existing Secrets referenced through
+`configSecret`, `usersSecret`, or `externalSecrets`. In particular, local and
+GitOps rendering does not have access to live Secret data, and using `lookup`
+would make rendering cluster-dependent without reliably detecting remote
+secret rotations. For source-controlled Secret changes, pass a revision or
+content hash as a pod annotation and update it with the Secret:
+
+```yaml
+podAnnotations:
+  checksum/external-config: "<revision-or-content-hash>"
+```
+
+For Secrets updated independently by a secrets operator, use a rollout
+controller and configure its watch annotation through `annotations`. For
+example, with Stakater Reloader:
+
+```yaml
+annotations:
+  secret.reloader.stakater.com/reload: "my-pgdog-config,my-pgdog-users"
+```
 
 ### ExternalSecrets Integration
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $checksumConfig := and .Values.restartOnConfigChange (not .Values.configSecret.name) }}
+{{- $checksumUsers := and .Values.restartOnConfigChange (not .Values.externalSecrets.enabled) (not .Values.usersSecret.name) }}
 apiVersion: apps/v1
 {{- if .Values.statefulSet.enabled }}
 kind: StatefulSet
@@ -33,10 +35,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "pgdog.selectorLabels" . | nindent 8 }}
-      {{- if or .Values.restartOnConfigChange .Values.podAnnotations }}
+      {{- if or $checksumConfig $checksumUsers .Values.podAnnotations }}
       annotations:
-        {{- if .Values.restartOnConfigChange }}
+        {{- if $checksumConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if $checksumUsers }}
+        checksum/users: {{ include "pgdog.users" . | sha256sum }}
         {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,5 +37,71 @@ else
   exit 1
 fi
 
+# Validate config change rollout checksums
+echo ""
+echo "==> Validating config change rollout checksums..."
+rollout_values="$TEST_DIR/values-restart-on-config-change.yaml"
+base_rendered=$(helm template test-release "$CHART_DIR" -f "$rollout_values")
+config_rendered=$(helm template test-release "$CHART_DIR" -f "$rollout_values" --set logLevel=debug)
+users_rendered=$(helm template test-release "$CHART_DIR" -f "$rollout_values" --set-string users[0].password=changed-password)
+secret_metadata_rendered=$(helm template test-release "$CHART_DIR" -f "$rollout_values" --set-string secret.annotations.example=value)
+
+base_config_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/config"' <<< "$base_rendered")
+base_users_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/users"' <<< "$base_rendered")
+changed_config_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/config"' <<< "$config_rendered")
+config_change_users_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/users"' <<< "$config_rendered")
+users_change_config_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/config"' <<< "$users_rendered")
+changed_users_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/users"' <<< "$users_rendered")
+metadata_users_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/users"' <<< "$secret_metadata_rendered")
+
+if [[ -z "$base_config_checksum" || "$base_config_checksum" == "null" ||
+      -z "$base_users_checksum" || "$base_users_checksum" == "null" ||
+      -z "$changed_config_checksum" || "$changed_config_checksum" == "null" ||
+      -z "$config_change_users_checksum" || "$config_change_users_checksum" == "null" ||
+      -z "$users_change_config_checksum" || "$users_change_config_checksum" == "null" ||
+      -z "$changed_users_checksum" || "$changed_users_checksum" == "null" ||
+      -z "$metadata_users_checksum" || "$metadata_users_checksum" == "null" ]]; then
+  echo "  FAIL: chart-rendered config checksums are missing"
+  exit 1
+fi
+
+if [[ "$base_config_checksum" == "$changed_config_checksum" ||
+      "$base_users_checksum" != "$config_change_users_checksum" ]]; then
+  echo "  FAIL: pgdog.toml changes did not update only checksum/config"
+  exit 1
+fi
+
+if [[ "$base_users_checksum" == "$changed_users_checksum" ||
+      "$base_config_checksum" != "$users_change_config_checksum" ]]; then
+  echo "  FAIL: users.toml changes did not update only checksum/users"
+  exit 1
+fi
+
+if [[ "$base_users_checksum" != "$metadata_users_checksum" ]]; then
+  echo "  FAIL: Secret metadata changed the users.toml checksum"
+  exit 1
+fi
+echo "  chart-rendered config checksums update independently"
+
+# Existing Secret contents are unavailable to Helm; retain only caller-provided
+# annotations instead of emitting constant, misleading checksums.
+external_rendered=$(helm template test-release "$CHART_DIR" \
+  -f "$TEST_DIR/values-existing-config-secret.yaml" \
+  --set restartOnConfigChange=true)
+external_config_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/config"' <<< "$external_rendered")
+external_users_checksum=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/users"' <<< "$external_rendered")
+external_revision=$(yq -r 'select(.kind == "Deployment") | .spec.template.metadata.annotations."checksum/external-config"' <<< "$external_rendered")
+
+if [[ "$external_config_checksum" != "null" || "$external_users_checksum" != "null" ]]; then
+  echo "  FAIL: external Secrets received chart-rendered content checksums"
+  exit 1
+fi
+
+if [[ "$external_revision" != "source-revision-1" ]]; then
+  echo "  FAIL: external config revision pod annotation was not preserved"
+  exit 1
+fi
+echo "  external Secrets rely on caller-provided rollout annotations"
+
 echo ""
 echo "==> All tests passed!"

--- a/test/values-existing-config-secret.yaml
+++ b/test/values-existing-config-secret.yaml
@@ -10,3 +10,7 @@ configSecret:
 usersSecret:
   name: my-pgdog-users
   key: users.toml
+
+# External Secret contents are represented by a source-controlled revision.
+podAnnotations:
+  checksum/external-config: source-revision-1

--- a/test/values-restart-on-config-change.yaml
+++ b/test/values-restart-on-config-change.yaml
@@ -1,0 +1,11 @@
+# Test opt-in rollouts for chart-rendered pgdog.toml and users.toml.
+restartOnConfigChange: true
+
+databases:
+  - name: primary
+    host: db.example.com
+
+users:
+  - name: app
+    database: primary
+    password: initial-password

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,9 @@ podLabels: {}
 # allows adding custom annotations to the pods
 podAnnotations: {}
 
-# restartOnConfigChange triggers a rolling restart when pgdog config changes.
+# restartOnConfigChange triggers a rolling restart when chart-rendered pgdog.toml
+# or users.toml content changes. It cannot detect changes to existing Secrets
+# referenced by configSecret, usersSecret, or externalSecrets.
 # Disabled by default; enable if you don't have a hot-reload mechanism (e.g. SIGHUP sidecar).
 # See: https://github.com/pgdogdev/helm/issues/15
 # restartOnConfigChange: false


### PR DESCRIPTION
# Motivation

`restartOnConfigChange` only hashes the chart's ConfigMap today. A `users.toml` password or user change updates the generated Secret but leaves PgDog pods running with the old configuration. This closes #116 for resources rendered by the chart while keeping restarts opt-in.

# Summary of Changes

- Add `checksum/users` for the exact `users.toml` content rendered by the chart.
- Emit managed checksums only when the chart renders the corresponding ConfigMap or Secret.
- Document safe rollout options for `configSecret`, `usersSecret`, and External Secrets without cluster-dependent `lookup` calls.
- Add focused tests for independent config and users changes, metadata-only changes, and external Secret annotations.

# Testing

- Render with `test/values-restart-on-config-change.yaml`, change `logLevel`, and confirm only `checksum/config` changes.
- Change the test user's password and confirm only `checksum/users` changes.
- Render `test/values-existing-config-secret.yaml` with `restartOnConfigChange=true` and confirm only the caller-provided external revision annotation is present.

# Dependencies/Special Considerations

Helm cannot read external Secret contents during local or GitOps rendering. Users must update a source-controlled hash through `podAnnotations` or use a rollout controller for secrets that rotate outside Helm.