### PR TITLE
feat: render password_hash for users

### DIFF
--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -8,6 +8,9 @@ passwords = [{{ range $i, $p := .passwords }}{{ if $i }}, {{ end }}{{ $p | quote
 {{- else if .password }}
 password = {{ .password | quote }}
 {{- end }}
+{{- if .passwordHash }}
+password_hash = {{ .passwordHash | quote }}
+{{- end }}
 {{- if .poolSize }}
 pool_size = {{ .poolSize }}
 {{- end }}

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,5 +37,28 @@ else
   exit 1
 fi
 
+# Validate password hash renders valid TOML
+echo ""
+echo "==> Validating password hash TOML output..."
+users_toml=$(helm template test-release "$CHART_DIR" -f "$TEST_DIR/values-password-hash.yaml" \
+  | yq -r 'select(.kind == "Secret" and .metadata.name == "test-release-pgdog") | .data["users.toml"]' \
+  | base64 -d)
+
+if echo "$users_toml" | grep -q 'password_hash = "SCRAM-SHA-256\$4096:'; then
+  echo "  password hash rendered correctly"
+else
+  echo "  FAIL: password hash not rendered correctly"
+  echo "  Got: $users_toml"
+  exit 1
+fi
+
+if echo "$users_toml" | grep -q '^password = '; then
+  echo "  FAIL: plaintext password rendered for a hash-only user"
+  echo "  Got: $users_toml"
+  exit 1
+else
+  echo "  no plaintext password rendered"
+fi
+
 echo ""
 echo "==> All tests passed!"

--- a/test/values-password-hash.yaml
+++ b/test/values-password-hash.yaml
@@ -1,0 +1,13 @@
+# Test a SCRAM verifier in place of a plaintext password.
+# PgDog requires passwordless backend auth when password_hash is used.
+databases:
+  - name: primary
+    host: postgres-primary.example.com
+    port: 5432
+
+users:
+  - name: app_user
+    database: primary
+    passwordHash: "SCRAM-SHA-256$4096:b6lksqhYfkXiN2hDMl3zfA==$9Rh0FdfjsbECkf289/WO2yHGiUBnNOOb1uNHVtOCCDE=:V7jC7GHvIr4guRsI66S3u4aXNhHWj1Pz71ymRM7bLFU="
+    serverUser: app_role
+    serverAuth: rds_iam

--- a/values.yaml
+++ b/values.yaml
@@ -233,6 +233,19 @@ databases: []
 # users contains the list of user entries in users.toml
 # Supports all arguments from users.toml. Arguments are named in
 # camelCase format.
+#
+# passwordHash accepts a PostgreSQL SCRAM verifier (the value stored in
+# pg_authid.rolpassword) instead of a plaintext password, so client logins can
+# be validated without keeping the password in users.toml. PgDog requires the
+# backend connection to authenticate without a password when it is used, e.g.
+# serverAuth: rds_iam.
+#
+#   users:
+#     - name: app_user
+#       database: primary
+#       passwordHash: "SCRAM-SHA-256$4096:<salt>$<StoredKey>:<ServerKey>"
+#       serverUser: app_role
+#       serverAuth: rds_iam
 users: []
 
 # mirrors contains a list of databases to replicate traffic from/to.


### PR DESCRIPTION
## What

`users.toml` supports [`password_hash`](https://github.com/pgdogdev/pgdog/blob/main/pgdog-config/src/users.rs) — a PostgreSQL SCRAM verifier (the value in `pg_authid.rolpassword`) used to validate client logins without keeping the plaintext password in the file. The chart's `users` documentation says it *"supports all arguments from users.toml"*, but the template has no branch for it, so `passwordHash` is silently dropped from the rendered file and the user ends up with no credential at all.

This adds the missing branch, documents the key in `values.yaml`, and covers it in the test suite.

## Why it renders independently of `password` / `passwords`

PgDog accepts both a plaintext password and a hash on the same user, and `Server::new` prefers the hash:

```rust
let hash = passwords.iter().find(|p| matches!(p, PasswordKind::Hashed(_)));
if let Some(hash) = hash { /* use the hash */ }
```

So `passwordHash` gets its own `if` rather than joining the `password` / `passwords` chain — the chart stays a faithful renderer of the config surface rather than imposing an ordering PgDog doesn't have.

## Pairing

PgDog requires the backend hop to authenticate without a password when `password_hash` is set, which the schema states explicitly: *"Server authentication must use RDS IAM or some other passwordless authentication."* So this pairs with `serverUser` / `serverAuth`, and is not a replacement for `serverPassword`. The new fixture reflects that.

## Testing

- `helm lint` clean
- All `test/values-*.yaml` fixtures still render
- New `test/values-password-hash.yaml`, picked up automatically by `test.sh`'s glob
- Two assertions added, in the style of the existing multiple-passwords checks: the hash renders, and no plaintext `password` line is emitted for a hash-only user
- Rendered `users.toml` verified to parse as TOML

`kubeconform` wasn't available locally, so CI will be the first to run that step. The diff only changes the contents of a Secret's `data` value, so it shouldn't affect schema conformance.

Rendered output:

```toml
[[users]]
name = "app_user"
database = "primary"
password_hash = "SCRAM-SHA-256$4096:b6lksqhYfkXiN2hDMl3zfA==$9Rh0…=:V7jC7…="
server_user = "app_role"
server_auth = "rds_iam"
```

## Unrelated observation

While validating, I noticed `test/values-full.yaml` uses `username:` and `poolMode:` instead of `name:` and `poolerMode:`. It renders syntactically invalid TOML — `name = ` with no value — on `main` today. CI passes because `kubeconform` validates the Kubernetes Secret, not the TOML inside it. Happy to send that as a separate PR if useful; I left it out to keep this one focused.