### PR TITLE
feat: render password_hash for users

### DIFF
--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -8,6 +8,9 @@ passwords = [{{ range $i, $p := .passwords }}{{ if $i }}, {{ end }}{{ $p | quote
 {{- else if .password }}
 password = {{ .password | quote }}
 {{- end }}
+{{- if .passwordHash }}
+password_hash = {{ .passwordHash | quote }}
+{{- end }}
 {{- if .poolSize }}
 pool_size = {{ .poolSize }}
 {{- end }}

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,5 +37,28 @@ else
   exit 1
 fi
 
+# Validate password hash renders valid TOML
+echo ""
+echo "==> Validating password hash TOML output..."
+users_toml=$(helm template test-release "$CHART_DIR" -f "$TEST_DIR/values-password-hash.yaml" \
+  | yq -r 'select(.kind == "Secret" and .metadata.name == "test-release-pgdog") | .data["users.toml"]' \
+  | base64 -d)
+
+if echo "$users_toml" | grep -q 'password_hash = "SCRAM-SHA-256\$4096:'; then
+  echo "  password hash rendered correctly"
+else
+  echo "  FAIL: password hash not rendered correctly"
+  echo "  Got: $users_toml"
+  exit 1
+fi
+
+if echo "$users_toml" | grep -q '^password = '; then
+  echo "  FAIL: plaintext password rendered for a hash-only user"
+  echo "  Got: $users_toml"
+  exit 1
+else
+  echo "  no plaintext password rendered"
+fi
+
 echo ""
 echo "==> All tests passed!"

--- a/test/values-password-hash.yaml
+++ b/test/values-password-hash.yaml
@@ -1,0 +1,17 @@
+# Test a SCRAM verifier in place of a plaintext password.
+# PgDog requires passwordless backend auth when password_hash is used.
+#
+# The verifier below is generated from the throwaway password
+# "pgdog-chart-test-password" with a fixed 16-byte salt, purely so this fixture
+# has a well-formed value to render. It is not a credential for anything.
+databases:
+  - name: primary
+    host: postgres-primary.example.com
+    port: 5432
+
+users:
+  - name: app_user
+    database: primary
+    passwordHash: "SCRAM-SHA-256$4096:AAECAwQFBgcICQoLDA0ODw==$4td+UR3YAWZ1KVIzL/2kUznOtnXa9WfGSd43hLG6MlE=:tpNtjd9V1KIFupdow3F2SEDGpKo53k/JYt6M2m5jtvo="
+    serverUser: app_role
+    serverAuth: rds_iam

--- a/values.yaml
+++ b/values.yaml
@@ -233,6 +233,19 @@ databases: []
 # users contains the list of user entries in users.toml
 # Supports all arguments from users.toml. Arguments are named in
 # camelCase format.
+#
+# passwordHash accepts a PostgreSQL SCRAM verifier (the value stored in
+# pg_authid.rolpassword) instead of a plaintext password, so client logins can
+# be validated without keeping the password in users.toml. PgDog requires the
+# backend connection to authenticate without a password when it is used, e.g.
+# serverAuth: rds_iam.
+#
+#   users:
+#     - name: app_user
+#       database: primary
+#       passwordHash: "SCRAM-SHA-256$4096:<salt>$<StoredKey>:<ServerKey>"
+#       serverUser: app_role
+#       serverAuth: rds_iam
 users: []
 
 # mirrors contains a list of databases to replicate traffic from/to.


### PR DESCRIPTION
Closes #132.

`users.toml` supports `password_hash` (a PostgreSQL SCRAM verifier), but the chart has no branch for it. `passwordHash` is dropped, and the user entry is rendered with no credential at all.

This adds the branch, documents the key in `values.yaml`, and adds a test.

**Why it matters:** when the backend connects without a password (`serverAuth: rds_iam`, or Vault), the frontend password is the only secret left in `users.toml`. A SCRAM verifier is safe to keep in git, because it cannot be replayed to log in.

**Notes:**

- Rendered as its own `if`, not another branch of the `passwords` / `password` chain, so a verifier can sit next to other settings.
- The verifier in the test fixture is generated from a throwaway password. It is not a real credential.

`test/test.sh` passes: 27 fixtures, 0 invalid, 0 errors. The new checks assert that the hash reaches `users.toml`, and that no plaintext `password` line is written for a hash-only user.
