### PR TITLE
fix: allow 0 for PDB minAvailable and maxUnavailable

### DIFF
--- a/templates/poddisruptionbudget.yaml
+++ b/templates/poddisruptionbudget.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "pgdog.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,5 +37,34 @@ else
   exit 1
 fi
 
+# Validate zero values survive on the PodDisruptionBudget
+echo ""
+echo "==> Validating PodDisruptionBudget zero values..."
+
+pdb_spec() {
+  helm template test-release "$CHART_DIR" -f "$1" \
+    | yq -r 'select(.kind == "PodDisruptionBudget") | .spec | del(.selector)'
+}
+
+min_available=$(pdb_spec "$TEST_DIR/values-pdb-min-available-zero.yaml")
+
+if [ "$min_available" = "minAvailable: 0" ]; then
+  echo "  minAvailable: 0 rendered correctly"
+else
+  echo "  FAIL: minAvailable: 0 not rendered correctly"
+  echo "  Got: $min_available"
+  exit 1
+fi
+
+max_unavailable=$(pdb_spec "$TEST_DIR/values-pdb-max-unavailable-zero.yaml")
+
+if [ "$max_unavailable" = "maxUnavailable: 0" ]; then
+  echo "  maxUnavailable: 0 rendered correctly"
+else
+  echo "  FAIL: maxUnavailable: 0 not rendered correctly"
+  echo "  Got: $max_unavailable"
+  exit 1
+fi
+
 echo ""
 echo "==> All tests passed!"

--- a/test/values-pdb-max-unavailable-zero.yaml
+++ b/test/values-pdb-max-unavailable-zero.yaml
@@ -1,0 +1,7 @@
+# maxUnavailable: 0 is a valid PDB value requiring zero voluntary evictions.
+# minAvailable is nulled because only one of the two fields may be set, and
+# values.yaml ships minAvailable: 1.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: null
+  maxUnavailable: 0

--- a/test/values-pdb-min-available-zero.yaml
+++ b/test/values-pdb-min-available-zero.yaml
@@ -1,0 +1,5 @@
+# minAvailable: 0 is a valid PDB value meaning zero pods must stay available.
+# It is falsy in Go templates, so it must be guarded on presence, not truthiness.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 0


### PR DESCRIPTION
Fixes #135.

Relates to helm/helm#3164

`0` is falsy in Go templates, so the truthiness guards dropped it - and
`maxUnavailable: 0` is the documented way to require zero voluntary evictions.
The PDB was still created, with an empty spec, which leaves `desiredHealthy` at
`0` and permits every disruption.

```diff
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
```

`kindIs "invalid"` is the nil test, so unset fields - and an explicit
`minAvailable: null`, needed to select `maxUnavailable` over the default - stay
omitted, while `0` renders.

Kept as two independent conditions rather than `if`/`else`: setting both fields
should keep failing loudly with *"minAvailable and maxUnavailable cannot be both
set"* rather than having the template silently drop one.

Adds a values file per field and asserts the rendered spec in `test/test.sh`.
`kubeconform` cannot catch this on its own - an empty PDB spec is schema-valid,
which is why the bug was silent. Both assertions fail with `Got: {}` against the
current template.

No change for anyone not setting `0`: the rendered PodDisruptionBudget is
identical across all 26 existing `test/values-*.yaml` files.
